### PR TITLE
fix of error defined(@array) is deprecated at ./check_file_content.pl…

### DIFF
--- a/check_file_content.pl
+++ b/check_file_content.pl
@@ -40,7 +40,7 @@ sub help
 
 sub check_args 
  {
-        help if !(defined(@ARGV));
+        help if !@ARGV;
         
         my ($file,@include,@exclude);
         my $num=1;


### PR DESCRIPTION
hello,
just a fix for the recent version of perl which gave the warning :

> defined(@array) is deprecated at ./check_file_content.pl line 43.
>         (Maybe you should just omit the defined()?)

thank you for your useful plugin
